### PR TITLE
Make idmind_{serial,interaction} build with catkin_build

### DIFF
--- a/idmind_interaction/CMakeLists.txt
+++ b/idmind_interaction/CMakeLists.txt
@@ -30,8 +30,13 @@ generate_messages(
 ## catkin specific configuration ##
 ###################################
 
-catkin_package()
-
+catkin_package(
+       INCLUDE_DIRS include
+       CATKIN_DEPENDS
+       std_msgs
+       message_runtime
+       geometry_msgs
+       )
 
 ###########
 ## Build ##
@@ -44,4 +49,4 @@ include_directories(
 
 add_executable(idmind_interaction src/idmind_interaction.cpp)
 add_dependencies(idmind_interaction ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-target_link_libraries(idmind_interaction idmind_serial ${catkin_LIBRARIES})
+target_link_libraries(idmind_interaction ${catkin_LIBRARIES})

--- a/idmind_serial/CMakeLists.txt
+++ b/idmind_serial/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(catkin REQUIRED COMPONENTS
 
 catkin_package(
   INCLUDE_DIRS include
+  LIBRARIES ${PROJECT_NAME}
 )
 
 ###########
@@ -25,3 +26,8 @@ add_library(idmind_serial src/${PROJECT_NAME}/idmind_serial.cpp)
 add_dependencies(idmind_serial ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 target_link_libraries(idmind_serial ${catkin_LIBRARIES})
+
+install(TARGETS ${PROJECT_NAME}
+	LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
+install(DIRECTORY include/${PROJECT_NAME}/
++       DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})


### PR DESCRIPTION
With this PR I can compile idmind_interaction. 
The resulting binary fails though, but this is because I do not have the needed hardware (I guess).

The error I receive is the same for all 3 options I used.
Before my changes with catkin_make, and after the changes with catkin_make and catkin build

`rosrun idmind_interaction idmind_interaction 
[ERROR] [1500995633.807072210]: SERIAL --> Could not open /dev/idmind-interactionboard: IO Exception (2): No such file or directory, file /tmp/binarydeb/ros-indigo-serial-1.2.1/src/impl/unix.cc, line 151.
[ERROR] [1500995633.836623549]: /idmind_interaction ---> FAILED <---
[ INFO] [1500995633.836676337]: Defining base LEDS...
`