### PR TITLE
Base movement fix with trajectory commands

### DIFF
--- a/kclhand_control/README.md
+++ b/kclhand_control/README.md
@@ -22,6 +22,18 @@ mode_id = 3, open hand
 mode_id = 4, switch hand configuration from the upper workspace to lower workspace
 mode_id = 5, switch hand configuration from the lower workspace to upper workspace
 mode_id = 6, print hand motor enable status
+mode_id = 9, fold hand
+
+
+So when launching the hand, please run the services with the following sequences 
+1. mode_id = 3, open hand. 
+2. mode_id = 5, switch hand configuration from the lower workspace to upper workspace 
+3. mode_id = 3, open hand.  （for preparing a grasp）
+4. mode_id = 2, close hand.  （grasp）
+
+when folding the hand, just use 
+mode_id = 9, fold hand
+
 
 
 ### 2. Finger position control

--- a/kclhand_control/scripts/kclhand_state_publisher.py
+++ b/kclhand_control/scripts/kclhand_state_publisher.py
@@ -27,9 +27,11 @@ class kclhand_state_publisher(object):
 
     def active_joint_callback(self, msg):
         # NOTE: kclhand_fingertip_state needs angles in degrees (though internally uses radians anyway ..)
-        joint_values_deg = range(0, len(msg.position))
-        for i in range(0, len(joint_values_deg)):
-            joint_values_deg[i] = m.degrees(msg.position[i])
+        #joint_values_deg = range(0, len(msg.position))
+        #for i in range(0, len(joint_values_deg)):
+        #    joint_values_deg[i] = m.degrees(msg.position[i])
+        # NOTE: active joint state is given in degrees, not radians
+        joint_values_deg = msg.position
         # NOTE: The minuses are right just so. It's an odd artefact of how handFK defines directions.
         fingertip_state = kclhand.HandFK(palmJointA = joint_values_deg[0],
                                          palmJointE = joint_values_deg[1],

--- a/squirrel_control/CMakeLists.txt
+++ b/squirrel_control/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(catkin REQUIRED
         nav_msgs
         tf
         control_msgs
+        sensor_msgs
 )
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)
@@ -51,6 +52,7 @@ catkin_package(
           nav_msgs
           tf
           control_msgs
+          sensor_msgs
         LIBRARIES
           squirrel_hw_control_loop
           squirrel_hw_interface

--- a/squirrel_control/include/squirrel_control/squirrel_hw_interface.h
+++ b/squirrel_control/include/squirrel_control/squirrel_hw_interface.h
@@ -35,9 +35,10 @@
 #include <squirrel_safety_msgs/Safety.h>
 #include <std_msgs/Int16.h>
 #include <std_msgs/Bool.h>
+#include <std_srvs/SetBool.h>
 #include <control_msgs/JointTrajectoryControllerState.h>
 #include <controller_manager_msgs/SwitchController.h>
-
+#include <sensor_msgs/JointState.h>
 
 namespace squirrel_control {
 
@@ -115,8 +116,16 @@ namespace squirrel_control {
 			virtual void odomCallback(const nav_msgs::OdometryConstPtr &msg);
 
 			virtual bool allClose(const std::vector<double> &a, const std::vector<double> &b, double error=1e-6);
+            
+            bool resetControllers(std_srvs::SetBool::Request &req, std_srvs::SetBool::Response &res);
+
+            bool getResetSignal();
+
+            virtual void commandCallback(const trajectory_msgs::JointTrajectoryConstPtr &msg);
 
 		protected:
+
+            bool reset_signal_;
 
 			/** \brief Get the URDF XML from the parameter server */
 			virtual void loadURDF(ros::NodeHandle& nh, std::string param_name);
@@ -190,6 +199,14 @@ namespace squirrel_control {
 			bool hold = true;
 			bool ignore_base = false;
 			std::vector<double> last_base_cmd_;
+
+            ros::ServiceServer reset_service_;
+            ros::Subscriber trajectory_command_sub_;
+            ros::Publisher state_pub_;
+            ros::Publisher control_pub_;
+            bool first_broadcast_;
+            std::vector<double> last_trajectory_goal_;
+            ros::Time last_trajectory_time_;
 	};
 
 }

--- a/squirrel_control/include/squirrel_control/squirrel_hw_interface.h
+++ b/squirrel_control/include/squirrel_control/squirrel_hw_interface.h
@@ -109,23 +109,17 @@ namespace squirrel_control {
 			std::string printCommandHelper();
 
 			/** \brief Callbacks */
-			//virtual void safetyCallback(const squirrel_safety_msgs::SafetyConstPtr &msg);
-
-			//virtual void safetyResetCallback(const std_msgs::BoolConstPtr &msg);
-
 			virtual void odomCallback(const nav_msgs::OdometryConstPtr &msg);
 
 			virtual bool allClose(const std::vector<double> &a, const std::vector<double> &b, double error=1e-6);
             
-            bool resetControllers(std_srvs::SetBool::Request &req, std_srvs::SetBool::Response &res);
+            //bool resetControllers(std_srvs::SetBool::Request &req, std_srvs::SetBool::Response &res);
 
             bool getResetSignal();
 
             virtual void commandCallback(const trajectory_msgs::JointTrajectoryConstPtr &msg);
 
 		protected:
-
-            bool reset_signal_;
 
 			/** \brief Get the URDF XML from the parameter server */
 			virtual void loadURDF(ros::NodeHandle& nh, std::string param_name);
@@ -183,6 +177,7 @@ namespace squirrel_control {
 
 			double posBuffer_[3];
 			double velBuffer_[3];
+            std::vector<double> base_cmds_;
 
 			// Base
 			ros::Publisher base_interface_;
@@ -200,7 +195,8 @@ namespace squirrel_control {
 			bool ignore_base = false;
 			std::vector<double> last_base_cmd_;
 
-            ros::ServiceServer reset_service_;
+            // Resetting controller
+            bool reset_signal_;
             ros::Subscriber trajectory_command_sub_;
             ros::Publisher state_pub_;
             ros::Publisher control_pub_;

--- a/squirrel_control/include/squirrel_control/squirrel_hw_interface.h
+++ b/squirrel_control/include/squirrel_control/squirrel_hw_interface.h
@@ -15,8 +15,6 @@
 #include <urdf/model.h>
 #include <geometry_msgs/Twist.h>
 #include <trajectory_msgs/JointTrajectory.h>
-#include <tf/transform_datatypes.h>
-#include <tf/transform_listener.h>
 
 // ROS Controls
 #include <hardware_interface/robot_hw.h>
@@ -34,10 +32,7 @@
 #include "control_modes.h"
 #include <squirrel_safety_msgs/Safety.h>
 #include <std_msgs/Int16.h>
-#include <std_msgs/Bool.h>
-#include <std_srvs/SetBool.h>
 #include <control_msgs/JointTrajectoryControllerState.h>
-#include <controller_manager_msgs/SwitchController.h>
 #include <sensor_msgs/JointState.h>
 
 namespace squirrel_control {
@@ -108,15 +103,16 @@ namespace squirrel_control {
 			/** \brief Helper for debugging a joint's command */
 			std::string printCommandHelper();
 
-			/** \brief Callbacks */
+			/** \brief Odom callback */
 			virtual void odomCallback(const nav_msgs::OdometryConstPtr &msg);
 
+            /** \brief Check if values in two vectors are within a specific threshold */
 			virtual bool allClose(const std::vector<double> &a, const std::vector<double> &b, double error=1e-6);
             
-            //bool resetControllers(std_srvs::SetBool::Request &req, std_srvs::SetBool::Response &res);
-
+            /** \brief Return the value of the reset signal */
             bool getResetSignal();
 
+            /** \brief Joint trajectory command callbacl */
             virtual void commandCallback(const trajectory_msgs::JointTrajectoryConstPtr &msg);
 
 		protected:
@@ -184,8 +180,8 @@ namespace squirrel_control {
 			ros::Subscriber base_state_;
 			BaseController base_controller_;
 			std::mutex odom_lock_;
-			tf::TransformListener transform_listener_;
-			tf::StampedTransform latest_common_transform_;
+			//tf::TransformListener transform_listener_;
+			//tf::StampedTransform latest_common_transform_;
 
 			// Motor interface
 			motor_control::MotorUtilities* motor_interface_;

--- a/squirrel_control/package.xml
+++ b/squirrel_control/package.xml
@@ -29,6 +29,7 @@
   <build_depend>nav_msgs</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>control_msgs</build_depend>
+  <build_depend>sensor_msgs</build_depend>
 
   <run_depend>cmake_modules</run_depend>
   <run_depend>armadillo</run_depend>
@@ -49,6 +50,7 @@
   <run_depend>nav_msgs</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>control_msgs</run_depend>
+  <run_depend>sensor_msgs</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/squirrel_control/src/squirrel_hw_control_loop.cpp
+++ b/squirrel_control/src/squirrel_hw_control_loop.cpp
@@ -59,7 +59,10 @@ namespace squirrel_control {
         hardware_interface_->read(elapsed_time_);
 
         // Control
-        controller_manager_->update(ros::Time::now(), elapsed_time_);
+        //controller_manager_->update(ros::Time::now(), elapsed_time_);
+        //if (hardware_interface_->getResetSignal())
+        //    ROS_INFO("Reset signal was issued ---------");
+        controller_manager_->update(ros::Time::now(), elapsed_time_, hardware_interface_->getResetSignal());
 
         // Output
         hardware_interface_->write(elapsed_time_);

--- a/squirrel_control/src/squirrel_hw_control_loop.cpp
+++ b/squirrel_control/src/squirrel_hw_control_loop.cpp
@@ -8,10 +8,11 @@
 namespace squirrel_control {
 
     SquirrelHWControlLoop::SquirrelHWControlLoop(ros::NodeHandle &nh,
-                                                 boost::shared_ptr <squirrel_control::SquirrelHWInterface> hardware_interface) :
-	nh_(nh), hardware_interface_(hardware_interface)
-{
-	std::cout << "Intializing loop..." << std::endl;
+                                                 boost::shared_ptr <squirrel_control::SquirrelHWInterface> hardware_interface)
+        : nh_(nh)
+          , hardware_interface_(hardware_interface)
+    {
+        std::cout << "Intializing loop..." << std::endl;
         // Create the controller manager
         controller_manager_.reset(new controller_manager::ControllerManager(hardware_interface_.get(), nh_));
 
@@ -29,7 +30,7 @@ namespace squirrel_control {
         ros::Duration desired_update_freq = ros::Duration(1 / loop_hz_);
         non_realtime_loop_ = nh_.createTimer(desired_update_freq, &SquirrelHWControlLoop::update, this);
 
-	std::cout << "Looping..." << std::endl;
+	    std::cout << "Looping..." << std::endl;
     }
 
 
@@ -60,8 +61,6 @@ namespace squirrel_control {
 
         // Control
         //controller_manager_->update(ros::Time::now(), elapsed_time_);
-        //if (hardware_interface_->getResetSignal())
-        //    ROS_INFO("Reset signal was issued ---------");
         controller_manager_->update(ros::Time::now(), elapsed_time_, hardware_interface_->getResetSignal());
 
         // Output

--- a/squirrel_control/src/squirrel_hw_control_loop.cpp
+++ b/squirrel_control/src/squirrel_hw_control_loop.cpp
@@ -60,7 +60,6 @@ namespace squirrel_control {
         hardware_interface_->read(elapsed_time_);
 
         // Control
-        //controller_manager_->update(ros::Time::now(), elapsed_time_);
         controller_manager_->update(ros::Time::now(), elapsed_time_, hardware_interface_->getResetSignal());
 
         // Output

--- a/squirrel_control/src/squirrel_hw_interface.cpp
+++ b/squirrel_control/src/squirrel_hw_interface.cpp
@@ -35,7 +35,6 @@ namespace squirrel_control {
 		motor_interface_ = new motor_control::MotorUtilities();
 		base_interface_ = rpnh.advertise<geometry_msgs::Twist>("/cmd_rotatory", 1);
 		base_state_ = rpnh.subscribe("/odom", 10, &SquirrelHWInterface::odomCallback, this);
-        //reset_service_ = rpnh.advertiseService("/squirrel_control/reset_controllers", &SquirrelHWInterface::resetControllers, this);
 		reset_signal_ = true;
         trajectory_command_sub_ = rpnh.subscribe("/arm_controller/joint_trajectory_controller/command", 10, &SquirrelHWInterface::commandCallback, this);
         ignore_base = true;
@@ -43,13 +42,6 @@ namespace squirrel_control {
         control_pub_ = rpnh.advertise<control_msgs::JointTrajectoryControllerState>("/arm_controller/joint_trajectory_controller/state", 1);
         first_broadcast_ = true;
         last_trajectory_goal_.resize(joint_names_.size());
-        /*
-		//Do we need to block until we get at least one transform? I guess so!
-		while(true) {
-			ros::Time now = ros::Time::now();
-			transform_listener_.waitForTransform("/map", "/base_link", now, ros::Duration(3.0));
-			break;
-		}*/
 	}
 
 
@@ -581,8 +573,6 @@ namespace squirrel_control {
 					base_interface_.publish(twist);			
 				}
                     
-                //std::cout << "All Close = " << allClose(joint_position_, last_trajectory_goal_, 1e-2) << std::endl;
-                //std::cout << "Time = " << ((ros::Time::now()-last_trajectory_time_).toSec() > 0.2) << " (" << (ros::Time::now()-last_trajectory_time_).toSec() << ")" << std::endl;
                 if(allClose(joint_position_, last_trajectory_goal_, 1e-2) &&
                    (ros::Time::now()-last_trajectory_time_).toSec() > 0.2) {
                     ROS_INFO("Command has finished");
@@ -619,24 +609,10 @@ namespace squirrel_control {
 		posBuffer_[0] = msg->pose.pose.position.x;
 		posBuffer_[1] = msg->pose.pose.position.y;
 		posBuffer_[2] = tf::getYaw(msg->pose.pose.orientation);
-        /*
-		ros::Time common_time;
-		std::string* error;
-		try{
-			transform_listener_.getLatestCommonTime("/base_link", "/map", common_time, error);
-			transform_listener_.lookupTransform("/map", "/base_link", common_time, latest_common_transform_);
-		} catch (tf::TransformException ex) {
-			ROS_WARN_STREAM_NAMED(name_, "Failed to retrieve most recent transfrom. Taking latest common known!");
-		}
-        
-		posBuffer_[0]+=latest_common_transform_.getOrigin().x();
-		posBuffer_[1]+=latest_common_transform_.getOrigin().y();
-		posBuffer_[2]+=tf::getYaw(latest_common_transform_.getRotation());
-		*/
-		velBuffer_[0] = msg->twist.twist.angular.x;
-		velBuffer_[1] = msg->twist.twist.angular.y;
-		velBuffer_[2] = msg->twist.twist.angular.z;
 		
+        velBuffer_[0] = msg->twist.twist.angular.x;
+		velBuffer_[1] = msg->twist.twist.angular.y;
+        velBuffer_[2] = msg->twist.twist.angular.z;	
 		odom_lock_.unlock();
 	}
 

--- a/squirrel_control/src/squirrel_hw_interface.cpp
+++ b/squirrel_control/src/squirrel_hw_interface.cpp
@@ -12,7 +12,7 @@ std::vector<double> base_cmds(3);
 
 namespace squirrel_control {
 	SquirrelHWInterface::SquirrelHWInterface(ros::NodeHandle &nh, urdf::Model *urdf_model)
-		: name_("squirrel_hw_interface")
+        : name_("squirrel_hw_interface")
 		  , nh_(nh)
 		  , use_rosparam_joint_limits_(false)
 		  , use_soft_limits_if_available_(false)
@@ -37,13 +37,21 @@ namespace squirrel_control {
 		motor_interface_ = new motor_control::MotorUtilities();
 		base_interface_ = rpnh.advertise<geometry_msgs::Twist>("/cmd_rotatory", 1);
 		base_state_ = rpnh.subscribe("/odom", 10, &SquirrelHWInterface::odomCallback, this);
-		
+        reset_service_ = rpnh.advertiseService("/squirrel_control/reset_controllers", &SquirrelHWInterface::resetControllers, this);
+		reset_signal_ = true;
+        trajectory_command_sub_ = rpnh.subscribe("/arm_controller/joint_trajectory_controller/command", 10, &SquirrelHWInterface::commandCallback, this);
+        ignore_base = true;
+        state_pub_ = rpnh.advertise<sensor_msgs::JointState>("/arm_controller/joint_states", 1);
+        control_pub_ = rpnh.advertise<control_msgs::JointTrajectoryControllerState>("/arm_controller/joint_trajectory_controller/state", 1);
+        first_broadcast_ = true;
+        last_trajectory_goal_.resize(joint_names_.size());
+        /*
 		//Do we need to block until we get at least one transform? I guess so!
 		while(true) {
 			ros::Time now = ros::Time::now();
 			transform_listener_.waitForTransform("/map", "/base_link", now, ros::Duration(3.0));
 			break;
-		}
+		}*/
 	}
 
 
@@ -357,10 +365,11 @@ namespace squirrel_control {
 
 	void SquirrelHWInterface::read(ros::Duration &elapsed_time) {
 		odom_lock_.lock();
+        auto positions = motor_interface_->read();
 		switch(current_mode_) {
 			case control_modes::POSITION_MODE:
 				{
-					auto positions = motor_interface_->read();
+					//auto positions = motor_interface_->read();
 					for(int i=0; i < joint_names_.size(); ++i)
 					{
 						if(joint_names_[i] == "base_jointx") {
@@ -414,6 +423,49 @@ namespace squirrel_control {
 				throw_control_error(true, "Unknown mode: " << current_mode_);
 		}
 		odom_lock_.unlock();
+        if((ignore_base && reset_signal_) || !first_broadcast_)
+        {
+            sensor_msgs::JointState current_joint_state;
+            current_joint_state.name.resize(8);
+            current_joint_state.position.resize(8);
+            current_joint_state.velocity = std::vector<double>(8,0.0);
+            current_joint_state.effort = std::vector<double>(8,0.0);
+            current_joint_state.name[0] = "arm_joint1";
+            current_joint_state.position[0] = positions[0];
+            current_joint_state.name[1] = "arm_joint2";
+            current_joint_state.position[1] = positions[1];
+            current_joint_state.name[2] = "arm_joint3";
+            current_joint_state.position[2] = positions[2];
+            current_joint_state.name[3] = "arm_joint4";
+            current_joint_state.position[3] = positions[3];
+            current_joint_state.name[4] = "arm_joint5";
+            current_joint_state.position[4] = positions[4];
+            current_joint_state.name[5] = "base_jointx";
+            current_joint_state.position[5] = posBuffer_[0];
+            current_joint_state.name[6] = "base_jointy";
+            current_joint_state.position[6] = posBuffer_[1];
+            current_joint_state.name[7] = "base_jointz";
+            current_joint_state.position[7] = posBuffer_[2];
+            current_joint_state.header.stamp = ros::Time::now();
+            state_pub_.publish(current_joint_state);
+            ros::spinOnce();
+            control_msgs::JointTrajectoryControllerState control_state;
+            control_state.joint_names = current_joint_state.name;
+            control_state.actual.positions = current_joint_state.position;
+            control_state.actual.velocities = std::vector<double>(8,0.0);
+            control_state.actual.accelerations = std::vector<double>(8,0.0);
+            control_state.actual.effort = std::vector<double>(8,0.0);
+            //control_state.actual.time_from_start = 0.0;
+            control_state.desired = control_state.actual;
+            control_state.error.positions = std::vector<double>(8,0.0);
+            control_state.error.velocities = std::vector<double>(8,0.0);
+            control_state.error.accelerations = std::vector<double>(8,0.0);
+            control_state.error.effort = std::vector<double>(8,0.0);
+            control_state.header.stamp = ros::Time::now();
+            control_pub_.publish(control_state);
+            ros::spinOnce();
+            first_broadcast_ = true;         
+        }
 	}
 
 
@@ -458,11 +510,14 @@ namespace squirrel_control {
 				}				
 			}     
 			hold = false;
+            first_broadcast_ = false;
 		}
+
 		enforceLimits(elapsed_time);    
 		std::vector<double> cmds(5);
 		geometry_msgs::Twist twist;
-
+        bool prev_ignore_base = ignore_base;
+        bool command_finished = false;
 		switch(current_mode_){
 			case control_modes::POSITION_MODE:
 				for(int i=0; i<joint_names_.size(); ++i) {
@@ -484,8 +539,8 @@ namespace squirrel_control {
 						cmds[4] = joint_position_command_[i];
 					}
 				}
-
-				ignore_base = allClose(base_cmds, last_base_cmd_);
+				//ignore_base = allClose(base_cmds, last_base_cmd_);
+                //command_finished = allClose(base_cmds, last_base_cmd_, 1e-9);
 				last_base_cmd_.clear();
 				last_base_cmd_ = base_cmds;
 				break;
@@ -519,25 +574,90 @@ namespace squirrel_control {
 				throw_control_error(true, "Unknown mode: " << current_mode_);
 		}
 
+        //if (reset_signal_)
+        //    ignore_base = true;
+
 		try {
 				motor_interface_->write(cmds);
+                /*
+                std::cout << "[] joint_position_\n";
+                for (size_t i = 0; i < joint_position_.size(); ++i)
+                    std::cout << joint_position_[i] << " ";
+                std::cout << "\n[] joint_position_command_\n";
+                for (size_t i = 0; i < joint_position_command_.size(); ++i)
+                    std::cout << joint_position_command_[i] << " ";
+                std::cout << "\n   * * *\n";
+                ignore_base = true;
+                */
 				if(!ignore_base) {
+                    /*
+                    if (prev_ignore_base)
+                    {
+                        ROS_INFO("Enforcing joint position command to joint position");
+                        joint_position_command_ = joint_position_;
+                    }
+                    */
+                    
+                    /*
+                    ROS_INFO("* * * Not ignoring base!");
+                    reset_signal_ = false; 
+                    std::cout << "joint_position_\n";
+                    for (size_t i = 0; i < joint_position_.size(); ++i)
+                        std::cout << joint_position_[i] << " ";
+                    std::cout << "\njoint_position_command_\n";
+                    for (size_t i = 0; i < joint_position_command_.size(); ++i)
+                        std::cout << joint_position_command_[i] << " ";
+                    std::cout << "\nlast_trajectory_goal_\n";
+                    for (size_t i = 0; i < last_trajectory_goal_.size(); ++i)
+                        std::cout << last_trajectory_goal_[i] << " ";
+                    std::cout << "\n   * * *\n";
+                    */
 					if (current_mode_ == control_modes::POSITION_MODE) {
-						base_controller_.moveBase(base_cmds.at(0), base_cmds.at(1), base_cmds.at(2));
+			            base_controller_.moveBase(base_cmds.at(0), base_cmds.at(1), base_cmds.at(2));
 					} else {
 						throw_control_error(true, "Not tested!");
 
 						base_interface_.publish(twist);			
 					}
-					ignore_base = true;
+					//ignore_base = true;
+                    
+
+                    /*
+                    // When do we exit!!!
+                    if(command_finished)
+                    {
+                        ROS_INFO("Command has finished");
+                        ignore_base = true;
+                        reset_signal_ = true;
+                    }
+                    */
+                    std::cout << "All Close = " << allClose(joint_position_, last_trajectory_goal_, 1e-2) << std::endl;
+                    std::cout << "Time = " << ((ros::Time::now()-last_trajectory_time_).toSec() > 0.2) << " (" << (ros::Time::now()-last_trajectory_time_).toSec() << ")" << std::endl;
+                    if(allClose(joint_position_, last_trajectory_goal_, 1e-2) &&
+                       (ros::Time::now()-last_trajectory_time_).toSec() > 0.2)
+                    {
+                        ROS_INFO("Command has finished");
+                        ignore_base = true;
+                        reset_signal_ = true;
+                    }
 				}
+                if (ignore_base && !prev_ignore_base)
+                {
+                    reset_signal_ = true;
+                    ROS_INFO("- - - Starting to ignore base!");
+                    std::cout << "joint_position_\n";
+                    for (size_t i = 0; i < joint_position_.size(); ++i)
+                        std::cout << joint_position_[i] << " ";
+                    std::cout << "\njoint_position_command_\n";
+                    for (size_t i = 0; i < joint_position_command_.size(); ++i)
+                        std::cout << joint_position_command_[i] << " ";
+                    std::cout << "\n   - - -\n";
+                }
+                
 		} catch (std::exception &ex) {
 			throw_control_error(true, ex.what());
 		}
 	}
-
-
-
 
 	void SquirrelHWInterface::enforceLimits(ros::Duration &period) {
 		// Enforces position and velocity
@@ -552,7 +672,7 @@ namespace squirrel_control {
 		posBuffer_[0] = msg->pose.pose.position.x;
 		posBuffer_[1] = msg->pose.pose.position.y;
 		posBuffer_[2] = tf::getYaw(msg->pose.pose.orientation);
-
+        /*
 		ros::Time common_time;
 		std::string* error;
 		try{
@@ -561,11 +681,11 @@ namespace squirrel_control {
 		} catch (tf::TransformException ex) {
 			ROS_WARN_STREAM_NAMED(name_, "Failed to retrieve most recent transfrom. Taking latest common known!");
 		}
-
+        
 		posBuffer_[0]+=latest_common_transform_.getOrigin().x();
 		posBuffer_[1]+=latest_common_transform_.getOrigin().y();
 		posBuffer_[2]+=tf::getYaw(latest_common_transform_.getRotation());
-		
+		*/
 		velBuffer_[0] = msg->twist.twist.angular.x;
 		velBuffer_[1] = msg->twist.twist.angular.y;
 		velBuffer_[2] = msg->twist.twist.angular.z;
@@ -573,5 +693,49 @@ namespace squirrel_control {
 		odom_lock_.unlock();
 	}
 
+    bool SquirrelHWInterface::resetControllers(std_srvs::SetBool::Request &req, std_srvs::SetBool::Response &res) {
+        if (req.data)
+            std::cout << "Received value TRUE" << std::endl;
+        else
+            std::cout << "Received value FALSE" << std::endl;
+        reset_signal_ = req.data;
+        /*
+        if (reset_signal_)
+        {
+            ros::Duration(3.0).sleep();
+            reset_signal_ = false;
+        }
+        */
+        res.success = true;
+        std::cout << "returning" << std::endl;
+        return true;
+    }
+
+    bool SquirrelHWInterface::getResetSignal() {
+        return reset_signal_;
+    }
+
+    void SquirrelHWInterface::commandCallback(const trajectory_msgs::JointTrajectoryConstPtr &msg)
+    {
+        ROS_INFO("Received a new command");
+        ignore_base = false;
+        reset_signal_ = false;
+        
+        // Store the last joint configuration from the command
+        last_trajectory_time_ = ros::Time::now();
+        int trajectory_length = msg->points.size();
+        last_trajectory_goal_.resize(joint_names_.size());
+        for(size_t i = 0; i < msg->points[trajectory_length-1].positions.size(); ++i)
+        {
+            if(msg->joint_names[i].compare("base_jointx") == 0) last_trajectory_goal_[0] = msg->points[trajectory_length-1].positions[i];
+            else if(msg->joint_names[i].compare("base_jointy") == 0) last_trajectory_goal_[1] = msg->points[trajectory_length-1].positions[i];
+            else if(msg->joint_names[i].compare("base_jointz") == 0) last_trajectory_goal_[2] = msg->points[trajectory_length-1].positions[i];
+            else if(msg->joint_names[i].compare("arm_joint1") == 0) last_trajectory_goal_[3] = msg->points[trajectory_length-1].positions[i];
+            else if(msg->joint_names[i].compare("arm_joint2") == 0) last_trajectory_goal_[4] = msg->points[trajectory_length-1].positions[i];
+            else if(msg->joint_names[i].compare("arm_joint3") == 0) last_trajectory_goal_[5] = msg->points[trajectory_length-1].positions[i];
+            else if(msg->joint_names[i].compare("arm_joint4") == 0) last_trajectory_goal_[6] = msg->points[trajectory_length-1].positions[i];
+            else if(msg->joint_names[i].compare("arm_joint5") == 0) last_trajectory_goal_[7] = msg->points[trajectory_length-1].positions[i]; 
+        }
+    }
 }
 

--- a/squirrel_interaction/src/squirrel_interaction/board/serial_api.py
+++ b/squirrel_interaction/src/squirrel_interaction/board/serial_api.py
@@ -223,7 +223,7 @@ def _limit_color(color_value):
 
 def _valid_destination(motor, degrees):
     if motor in ['head', 'neck']:
-        return max(-180, min(180, degrees))
+        return max(-50, min(50, degrees))
     if motor == 'camera':
         return max(-68, min(30, degrees))
     if motor == 'door':

--- a/squirrel_interaction/src/squirrel_interaction/screen/raspberry_screen_server.py
+++ b/squirrel_interaction/src/squirrel_interaction/screen/raspberry_screen_server.py
@@ -56,9 +56,10 @@ def main():
     img_file= "{}/resources/media/images/{}/{}.png".format(PATH, "gold", "look_down")
     rospy.loginfo("Ready to display on screen")
 
-    r = rospy.Rate(30)
+    r = rospy.Rate(1)
     while not rospy.is_shutdown():
         image = cv2.imread(img_file)
+        image = cv2.resize(image, (1280,720))
         cv2.imshow('image', image)
         cv2.waitKey(20)
         r.sleep()

--- a/squirrel_sensing_node/include/squirrel_sensing_node/node.h
+++ b/squirrel_sensing_node/include/squirrel_sensing_node/node.h
@@ -10,7 +10,7 @@
 #include "common_defines.h"
 
 //comment below line to disable wrist sensor (in case it is not plugged in)
-#define _FT17_AVAIL
+// #define _FT17_AVAIL
 
 enum Param
 {


### PR DESCRIPTION
Robot resets the joint trajectory controller (thus clears buffer in ros control) when not receiving trajectory commands. This prevents unwanted base movements when transitioning between controller, navigation and joystick. Essentially this is a hack to get around the problems with ros control. @lokalmatador @smhaller please check on Innsbruck robot.